### PR TITLE
Improved documentation and defaults for chunk_size and maxsize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,9 @@ FILES=`find . -name '*.py'`
 # The command for running mypy:
 lint:
 	python3 -m mypy $(FILES)
+
+# Run the unit tests.
+test:
+	python3 -m pytest -s pyrallel/tests/test_map_reduce.py
+	python3 -m pytest -s pyrallel/tests/test_parallel_processor.py
+	python3 -m pytest -s pyrallel/tests/test_queue.py


### PR DESCRIPTION
I improved the documentation regarding chunk_size, maxsize, and the serialized message size. I added two new symbolic constants for the default chunk size and default maxsize. I fixed typos in the documentation.